### PR TITLE
Add git attributes file for windows compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
- added git attributes file to preserve original line endings when checking out on windows.
- Behavior remains the same for mac