### PR TITLE
Add network setting to kafka service and kafka tester

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,8 @@ services:
       # points to the real keystore when the kafka server is started.
       - ./kafka/kafka.keystore.jks:/bitnami/kafka/config/certs/kafka.keystore.jks
       - ./kafka/kafka.properties:/bitnami/kafka/config/kafka.properties
+    networks:
+      - callisto
     environment:
       KAFKA_ENABLE_KRAFT: yes
       KAFKA_CFG_PROCESS_ROLES: broker,controller
@@ -126,6 +128,8 @@ services:
   kafka-tester:
     pull_policy: ${PULL_POLICY}
     image: bitnami/kafka:3.3
+    networks:
+      - callisto
     volumes:
       - keystore:/keystore
       - ./kafka/kafka-producer.properties:/bitnami/kafka/config/kafka-producer.properties


### PR DESCRIPTION
Update to docker compose yaml as the kafka service wasn't on the callisto network. It had gone unnoticed until now as the kafka tester service was also on the default network meaning that it worked but we had failures when attaching the timecard service to kafka.