### PR TITLE
Manage kafka ACL group permissions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,9 @@ services:
         condition: service_completed_successfully
       kafka-topics-acls:
         condition: service_completed_successfully
+    networks:
+      - callisto
+
 
   ingress:
     image: nginx:1.19.2-alpine

--- a/kafka/setup_scripts/README.md
+++ b/kafka/setup_scripts/README.md
@@ -23,12 +23,9 @@ the line with a #. Comments can not be added to the end of lines.
 ### ACL Instruction
 
 The first eligble line (not empty or comments) of the file must be an
-instruction line. The ACL instruction uses the --topic and 
+instruction line. The ACL instruction uses the --group, --topic and 
 --resource-pattern-type parameters typically used in the kafka-acl tool.
-
 This instruction is used to target the ACL to be configured.
-**The order of the arguments is important.** It must be in the order
---topic [value] followed by --resource-pattern-type [value].
 
 Neither value provided can include whitespace.
 Valid arguments for --resource-pattern-type are prefixed and literal
@@ -69,8 +66,15 @@ timecard-entries topic.
 --topic timecard --resource-pattern-type prefixed 
 User:timecard-service   Write       Allow
 User:timecard-service   Describe    Allow
+User:kafka-consumer     Read        Allow
 
 # Accruals can only read fre
 --topic timecard-entries --resource-pattern-type literal 
 User:accrual-service    Read       Allow
+
+# An empty instruction will cause any existing permissions to be removed
+--group callisto-dodgy-consumer --resource-pattern-type prefixed 
+
+--group console-consumer --resource-pattern-type prefixed 
+User:kafka-consumer      All            Allow
 ```

--- a/kafka/setup_scripts/kafka.sh
+++ b/kafka/setup_scripts/kafka.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Ensures a topic exists
-ensure_topic_exists() {
+function ensure_topic_exists() {
     local topic=$1
 
     kafka-topics.sh --bootstrap-server $kafka_host --command-config $properties_file \
@@ -18,17 +18,15 @@ ensure_topic_exists() {
 # get_current_acl timecard prefixed 
 # Example: Get permissions for topic timecard
 # get_current_acl timecard literal
-get_current_acl() {
+function get_current_acl() {
 
-    local topic=$1
-    local type=$2
     local acls
 
     # Call the kafka-acl script with relevant arguments and grep only the lines
     # form the output with the principals. Then use sed to strip out everything
     # but the required values leaving us with a space delimited list of existing
     # permissions   
-    IFS=$'\n' acls=( $(kafka-acls.sh --bootstrap-server $kafka_host --command-config $properties_file --list --topic $topic --resource-pattern-type $type | grep -o -e '(principal.*)' | sed -E 's/.*principal=(.*), host=\*, operation=(.*), permissionType=(.*)\)/\1 \2 \3/') )
+    IFS=$'\n' acls=( $(kafka-acls.sh --bootstrap-server $kafka_host --command-config $properties_file --list "${@}" | grep -o -e '(principal.*)' | sed -E 's/.*principal=(.*), host=\*, operation=(.*), permissionType=(.*)\)/\1 \2 \3/') )
 
     echo "${acls[*]/%/$'\n'}"
 
@@ -37,17 +35,15 @@ get_current_acl() {
 # Function to set the ACL for the given topic and pattern type
 # to the specified ACL
 set_permissions() {
-
-    local topic=$1
-    local type=$2
-    local desired_permissions=($3)
+    local parameters=("${@:1:$#-1}")
+    local desired_permissions=(${*: -1:1})
     local existing_permissions=()
     local set details principal operation permission
 
-    echo Applying desired permissions for $topic $type
+    echo Applying desired permissions for "${parameters[@]}"
 
     # get the current ACL for given topic and pattern type
-    local current_acl=($(get_current_acl $topic $type))
+    local current_acl=($(get_current_acl "${parameters[@]}"))
 
     # Iterate the current ACL to see if each existing permission
     # is still required. Remove any that are not desired
@@ -65,7 +61,7 @@ set_permissions() {
             echo Removing: ${principal} ${operation} ${permission}
             kafka-acls.sh --bootstrap-server $kafka_host \
                 --command-config $properties_file \
-                --topic $topic --resource-pattern-type $type \
+                "${parameters[@]}" \
                 --remove --force \
                 --${permission,,}-principal $principal --operation $operation \
                 > /dev/null
@@ -93,7 +89,7 @@ set_permissions() {
             echo Adding: ${principal} ${operation} ${permission}
             kafka-acls.sh --bootstrap-server $kafka_host \
                 --command-config $properties_file \
-                --topic $topic --resource-pattern-type $type \
+                "${parameters[@]}" \
                 --add --force \
                 --${permission,,}-principal $principal --operation $operation \
                 > /dev/null
@@ -105,7 +101,7 @@ set_permissions() {
 function apply_permissions() {
 
     local acl_config line
-    local details topic pattern_type
+    local details command_args topic pattern_type
     local permissions principal operation permission
 
     # read through the contents of the permissions file and
@@ -119,17 +115,18 @@ function apply_permissions() {
         details=($line)
 
         # if first argument is --topic assume a new list of permissions are being specified
-        if [ "${details[0]}" = "--topic" ]
+        if [[ "${details[0]}" =~ "--" ]]
         then
             # if permissions have already been specified for a previous topic
             # apply them.
-            if [ -n "$topic" ]
+            if [ -n "$command_args" ]
             then
                 IFS=$'\n'
-                set_permissions $topic $pattern_type "${permissions[*]/%/$'\n'}"
+                set_permissions "${command_args[@]}" "${permissions[*]/%/$'\n'}"
                 unset IFS
             fi
             # Reset the variables
+            command_args=("${details[@]}")
             topic=${details[1]}
             pattern_type=${details[3]}
             permissions=()
@@ -148,10 +145,10 @@ function apply_permissions() {
 
     # The end of the file has been reached. If a topic
     # was set apply the permissions.
-    if [ -n "$topic" ]
+    if [ -n "$command_args" ]
     then 
         IFS=$'\n'
-        set_permissions $topic $pattern_type "${permissions[*]/%/$'\n'}"
+        set_permissions "${command_args[@]}" "${permissions[*]/%/$'\n'}"
         unset IFS
     fi
 }

--- a/kafka/setup_scripts/permissions.txt
+++ b/kafka/setup_scripts/permissions.txt
@@ -1,8 +1,8 @@
 # Timecard prefix permissions
---topic timecard --resource-pattern-type prefixed 
-User:kafka-producer     Write       Allow
-User:kafka-producer     Describe    Allow
+--topic callisto-timecard --resource-pattern-type literal 
+User:timecard-restapi    Write       Allow
+User:timecard-restapi    Describe    Allow
+User:kafka-consumer      Read        Allow
 
-# Timecard timeentries permissions
---topic timecard-timeentries --resource-pattern-type literal 
-User:kafka-consumer     Read       Allow
+--group console-consumer --resource-pattern-type prefixed 
+User:kafka-consumer      All            Allow


### PR DESCRIPTION
Updated the scripts that manage the ACLs so that it now no longer parses the "instruction" line in the permissions.txt file but just passes through the options to the kafka command called. This allows us to use the exact same mechanism for managing ACLs for topics to manage ACLs for groups