### PR TITLE
Fix browser router by serving index

### DIFF
--- a/ingress/default.conf
+++ b/ingress/default.conf
@@ -35,10 +35,18 @@
                 add_header 'Access-Control-Allow-Origin' 'https://web.callisto.localhost' always;
                 add_header 'Access-Control-Allow-Credentials' 'true';
             }
+
+            set $full_uri '$host$request_uri';
+            set $upstream_request_uri $request_uri;
+
+            if ($full_uri ~* "web.callisto.localhost/(?!(assets/|silent-check-sso))") {
+                set $upstream_request_uri /;
+            }
+            
             add_header 'Access-Control-Allow-Methods' '*' always;
             add_header 'Access-Control-Allow-Headers' '*' always;
 
-            proxy_pass         http://$subdomain:9090;
+            proxy_pass         http://$subdomain:9090$upstream_request_uri;
             proxy_redirect     off;
             proxy_http_version 1.1;
             proxy_cache_bypass $http_upgrade;


### PR DESCRIPTION
Changing back to browser router means that without an isomorphic react app we need to respond with the index page. This change means that local dev will work when refreshing the browser page as the react app will be served instead of getting a 404 response