### PR TITLE
Add another exception for a public/static folder in the react ui

### DIFF
--- a/ingress/default.conf
+++ b/ingress/default.conf
@@ -39,7 +39,7 @@
             set $full_uri '$host$request_uri';
             set $upstream_request_uri $request_uri;
 
-            if ($full_uri ~* "web.callisto.localhost/(?!(src/|@|node_modules/|assets/|silent-check-sso))") {
+            if ($full_uri ~* "web.callisto.localhost/(?!(src/|@|node_modules/|static/|assets/|silent-check-sso))") {
                 set $upstream_request_uri /;
             }
             


### PR DESCRIPTION
We noticed that files outside of the react application (that are placed in the public folder) are no longer reachable due to the rules rewriting URLs to serve the index.html. As we can't accommodate all potential filenames we've introduce a single subfolder under the `public` folder called `static`. This results in all URLs starting with `static` e.g. `/static/emblem.jpg`. Then URLs starting `/static` can be excluded from the rewrite.