### PR TITLE
Fix balance calculator in localdev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -324,6 +324,7 @@ services:
     image: "quay.io/ukhomeofficedigital/callisto-balance-calculator:$BALANCE_CALCULATOR_TAG"
     environment:
       BOOTSTRAP_SERVER: kafka:9093
+      ACCRUALS_URL: http://callisto-accruals-restapi:9090
       KEYSTORE_LOCATION: file://keystore/balance-calculator/balance-calculator.keystore.jks
       KEYSTORE_PASSWORD: changeit
       SPRING_APPLICATION_JSON: '{

--- a/kafka/setup_scripts/permissions.txt
+++ b/kafka/setup_scripts/permissions.txt
@@ -18,3 +18,6 @@ User:balance-calculator        All         Allow
 User:accruals-person-consumer  All         Allow
 User:kafka-consumer            All         Allow
 
+--group balance-calculator --resource-pattern-type prefixed
+User:balance-calculator        Read         Allow
+


### PR DESCRIPTION
This PR adds balance-calculator as a consumer group in the permissions.txt and adds an environment variable for the accruals URL which differs from our production environments.